### PR TITLE
Crawlera should be disabled in the settings

### DIFF
--- a/splash_crawlera_example/splash_crawlera_example/settings.py
+++ b/splash_crawlera_example/splash_crawlera_example/settings.py
@@ -14,6 +14,7 @@ DOWNLOADER_MIDDLEWARES = {
     'scrapy.downloadermiddlewares.httpcompression.HttpCompressionMiddleware': 810,
 }
 
+CRAWLERA_ENABLED = False
 CRAWLERA_APIKEY = ''  # Your crawlera API key
 
 # Splash settings


### PR DESCRIPTION
To preserve the proper flow of requests. Calls to Crawlera are handled by the Lua script itself.